### PR TITLE
Unique Port, icon, and build enhancements

### DIFF
--- a/.cursor/rules/mcp-defender-overview.mdc
+++ b/.cursor/rules/mcp-defender-overview.mdc
@@ -68,12 +68,12 @@ Verification is currently done for tool requests and responses
 8. Approved response is forwarded back to the client
 
 #### SSE Verification Flow
- Client's MCP config is configured to use our MCP defender url instead of the original URL (http://localhost:8081) corresoponds to MCP Defender:
+ Client's MCP config is configured to use our MCP defender url instead of the original URL (http://localhost:28173) corresoponds to MCP Defender:
 ```json
 {
   "mcpServers": {
     "everything": {
-      "url": "http://localhost:8081/everything/sse",
+      "url": "http://localhost:28173/everything/sse",
       "env": {
       }
     }

--- a/.env.development
+++ b/.env.development
@@ -1,3 +1,0 @@
-NODE_ENV=development
-DEBUG=true
-PROXY_PORT=8081 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+## Problem
+
+<!-- Describe the feature or provide steps to repro the issue -->
+
+## Changes
+
+## Did you write or update any docs for this change?
+
+- [ ] I've added or updated the docs
+- [ ] I've reached out for help from the docs team
+- [ ] No docs needed for this change
+
+## How did you test this code?
+
+<!-- Describe the steps you took -->

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -33,7 +33,6 @@
       "dependsOrder": "sequence",
       "dependsOn": [
         "Build CLI",
-        "Kill Processes on Port 8081"
       ],
       "problemMatcher": [],
       "group": "build",
@@ -63,20 +62,9 @@
       }
     },
     {
-      "label": "Kill Processes on Port 8081",
-      "type": "shell",
-      "command": "lsof -ti:8081 | xargs kill -9 || echo 'No processes on port 8081'",
-      "presentation": {
-        "reveal": "never",
-        "panel": "shared"
-      },
-      "problemMatcher": []
-    },
-    {
       "label": "Prepare Debug Environment",
       "dependsOrder": "sequence",
       "dependsOn": [
-        "Kill Processes on Port 8081",
         "Build CLI"
       ],
       "problemMatcher": []

--- a/PROXY.md
+++ b/PROXY.md
@@ -13,7 +13,7 @@ Client Configuration:
 {
   "mcpServers": {
     "everything": {
-      "url": "http://localhost:8081/everything/sse",
+      "url": "http://localhost:28173/everything/sse",
       "env": {}
     }
   }
@@ -30,7 +30,7 @@ Client Configuration:
 {
   "mcpServers": {
     "everything": {
-      "url": "http://localhost:8081/everything",
+      "url": "http://localhost:28173/everything",
       "env": {}
     }
   }

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -89,11 +89,14 @@ const config: ForgeConfig = {
       }
     ],
     osxSign: {}, // This must exist even if empty for notarization to work.
-    osxNotarize: {
-      appleApiKey: app_store_api_data["APPLE_API_KEY"],
-      appleApiKeyId: app_store_api_data["APPLE_API_KEY_ID"],
-      appleApiIssuer: app_store_api_data["APPLE_API_ISSUER"]
-    },
+    // Only include notarization if SKIP_NOTARIZE is not set
+    ...(process.env.SKIP_NOTARIZE !== 'true' && {
+      osxNotarize: {
+        appleApiKey: app_store_api_data["APPLE_API_KEY"],
+        appleApiKeyId: app_store_api_data["APPLE_API_KEY_ID"],
+        appleApiIssuer: app_store_api_data["APPLE_API_ISSUER"]
+      }
+    }),
   },
   rebuildConfig: {},
   makers: [

--- a/mcp-defender-overview.mdc
+++ b/mcp-defender-overview.mdc
@@ -101,12 +101,12 @@ Verification is currently done for tool requests and responses
 8. Approved response is forwarded back to the client
 
 #### SSE Verification Flow
- Client's MCP config is configured to use our MCP defender url instead of the original URL (http://localhost:8081) corresoponds to MCP Defender:
+ Client's MCP config is configured to use our MCP defender url instead of the original URL (http://localhost:28173) corresoponds to MCP Defender:
 ```json
 {
   "mcpServers": {
     "everything": {
-      "url": "http://localhost:8081/everything/sse",
+      "url": "http://localhost:28173/everything/sse",
       "env": {
       }
     }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
   "scripts": {
     "start": "electron-forge start",
     "package": "electron-forge package",
+    "package:test": "SKIP_NOTARIZE=true electron-forge package",
     "make": "electron-forge make",
+    "make:test": "SKIP_NOTARIZE=true electron-forge make",
     "publish": "electron-forge publish",
     "lint": "eslint --ext .ts,.tsx .",
     "build:cli": "rm -rf dist/bin/cli.js && mkdir -p dist/bin && npx esbuild src/cli.ts --bundle --platform=node --outfile=dist/bin/cli.js && chmod +x dist/bin/cli.js",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,7 +19,7 @@ const CONFIG = {
     // Enable debug mode with --debug flag or MCP_DEBUG=true environment variable
     // Add this to your MCP configuration env section for more detailed logs
     debug: true,
-    defenderPort: 8081,
+    defenderPort: 28173,
     defenderHost: '127.0.0.1',
     // Use environment variable for log dir or default to OS temp directory
     logDir: process.env.MCP_DEFENDER_LOG_DIR || path.join(os.homedir(), '.mcp-defender', 'logs'),

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -20,6 +20,7 @@ import ScanDetailView from "./ScanDetailView";
 import SecurityAlertView from "./SecurityAlertView";
 import { Loader2 } from "lucide-react";
 import SettingsView from "./settings/SettingsView";
+import mcpDefenderLogo from "../assets/mcp-defender-logo.png";
 
 // Import types from existing code
 import { DefenderState, DefenderStatus } from "../services/defender/types";
@@ -207,9 +208,24 @@ export default function App() {
   if (isLoading) {
     return (
       <div className="flex items-center justify-center min-h-screen">
-        <div className="text-center space-y-4">
-          <Loader2 className="h-12 w-12 animate-spin mx-auto text-primary" />
-          <h2 className="text-xl font-medium">Initializing MCP Defender...</h2>
+        <div className="text-center space-y-6">
+          {/* Logo with background effect */}
+          <div className="flex justify-center">
+            <div className="relative">
+              <div className="absolute inset-0 bg-primary/10 rounded-full blur-lg"></div>
+              <img
+                src={mcpDefenderLogo}
+                alt="MCP Defender Logo"
+                className="h-20 w-20 object-contain relative z-10"
+              />
+            </div>
+          </div>
+
+          {/* Loading spinner and text */}
+          <div className="space-y-3">
+            <Loader2 className="h-8 w-8 animate-spin mx-auto text-primary" />
+            <h2 className="text-xl font-medium">Initializing MCP Defender...</h2>
+          </div>
         </div>
       </div>
     );

--- a/src/defender/defender-controller.ts
+++ b/src/defender/defender-controller.ts
@@ -28,7 +28,7 @@ import { ScanMode } from '../services/settings/types';
 // Server configuration
 // TODO: get this from settings later
 const SERVER_CONFIG = {
-  port: 8081,
+  port: 28173,
   host: '127.0.0.1'
 };
 

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -194,5 +194,11 @@ declare global {
       // Listen for defender state updates
       onStateUpdate: (callback: (state: DefenderState) => void) => () => void;
     }
+
+    // Utility API
+    utilityAPI: {
+      // Get the correct path to a resource
+      getResourcePath: (resourcePath: string) => Promise<string>;
+    }
   }
 } 

--- a/src/ipc-handlers/ui-manager.ts
+++ b/src/ipc-handlers/ui-manager.ts
@@ -720,6 +720,18 @@ export function registerUIHandlers() {
         closeSettingsWindow();
         return true;
     });
+
+    // Register handler for getting resource paths
+    ipcMain.handle('utilityAPI:getResourcePath', async (event, resourcePath: string) => {
+        // Determine the correct path based on the environment
+        if (app.isPackaged) {
+            // In production, resources are in the app bundle's Resources directory
+            return path.join(process.resourcesPath, resourcePath);
+        } else {
+            // In development, use the source path
+            return path.join(app.getAppPath(), 'src', 'assets', resourcePath);
+        }
+    });
 }
 
 /**

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -235,3 +235,9 @@ contextBridge.exposeInMainWorld('securityAPI', {
     return ipcRenderer.send('security-alert-decision', { scanId, allowed, remember });
   }
 });
+
+// Utility API
+contextBridge.exposeInMainWorld('utilityAPI', {
+  // Get the correct path to a resource
+  getResourcePath: (resourcePath: string) => ipcRenderer.invoke('utilityAPI:getResourcePath', resourcePath)
+});

--- a/src/services/configurations/base-configuration.ts
+++ b/src/services/configurations/base-configuration.ts
@@ -18,7 +18,7 @@ const logger = createLogger('BaseConfiguration');
  * This two-step approach simplifies the process and avoids complex conditional logic.
  */
 export abstract class BaseMCPConfiguration {
-    protected proxyPort: number = 8081;
+    protected proxyPort: number = 28173;
     protected cliPath: string;
 
     // App metadata

--- a/src/utils/icons.ts
+++ b/src/utils/icons.ts
@@ -2,14 +2,70 @@
  * Icon utility functions for application icons
  */
 
-// Mapping of application names to icon identifiers
-// These will be resolved to actual images later
-export const AppNameToIconPath: Record<string, string> = {
-    'Cursor': './src/assets/mcp_app_icons/cursor.png',
-    'Visual Studio Code': './src/assets/mcp_app_icons/vscode.png',
-    'Claude Desktop': './src/assets/mcp_app_icons/claude.png',
-    'Windsurf': './src/assets/mcp_app_icons/windsurf.png',
+// Import icon assets for Vite development
+import cursorIcon from '../assets/mcp_app_icons/cursor.png';
+import vscodeIcon from '../assets/mcp_app_icons/vscode.png';
+import claudeIcon from '../assets/mcp_app_icons/claude.png';
+import windsurfIcon from '../assets/mcp_app_icons/windsurf.png';
+import clineIcon from '../assets/mcp_app_icons/cline.png';
+
+// Icon mapping for development (using Vite imports)
+const developmentIconPaths = {
+    'Cursor': cursorIcon,
+    'Visual Studio Code': vscodeIcon,
+    'Claude Desktop': claudeIcon,
+    'Windsurf': windsurfIcon,
+    'Cline': clineIcon,
+};
+
+// Base icon paths for production (without the resource protocol)
+const productionIconPaths = {
+    'Cursor': 'mcp_app_icons/cursor.png',
+    'Visual Studio Code': 'mcp_app_icons/vscode.png',
+    'Claude Desktop': 'mcp_app_icons/claude.png',
+    'Windsurf': 'mcp_app_icons/windsurf.png',
+    'Cline': 'mcp_app_icons/cline.png',
     // Add more app icons as needed
+};
+
+/**
+ * Get the resolved path for an app icon
+ * @param appName Name of the application
+ * @returns Promise that resolves to the full path to the icon, or undefined if not found
+ */
+export async function getAppIconPath(appName: string): Promise<string | undefined> {
+    // Check if we have an icon for this app
+    const devIcon = developmentIconPaths[appName as keyof typeof developmentIconPaths];
+    const prodIconPath = productionIconPaths[appName as keyof typeof productionIconPaths];
+
+    if (!devIcon && !prodIconPath) return undefined;
+
+    // In development, use the imported asset URLs
+    if (import.meta.env.DEV) {
+        return devIcon;
+    }
+
+    // In production, use the utility API to get the proper resource path
+    if (typeof window !== 'undefined' && (window as any).utilityAPI) {
+        try {
+            return await (window as any).utilityAPI.getResourcePath(prodIconPath);
+        } catch (error) {
+            console.error('Failed to resolve icon path:', error);
+            return undefined;
+        }
+    }
+
+    // Fallback 
+    return undefined;
+}
+
+// Legacy mapping for backwards compatibility
+export const AppNameToIconPath: Record<string, string> = {
+    'Cursor': 'mcp_app_icons/cursor.png',
+    'Visual Studio Code': 'mcp_app_icons/vscode.png',
+    'Claude Desktop': 'mcp_app_icons/claude.png',
+    'Windsurf': 'mcp_app_icons/windsurf.png',
+    'Cline': 'mcp_app_icons/cline.png',
 };
 
 /**

--- a/tests/integration/mcp-defender/test-runner.ts
+++ b/tests/integration/mcp-defender/test-runner.ts
@@ -141,7 +141,7 @@ describe('MCP Defender Integration Tests', () => {
             // Wait for defender to be ready
             const isReady = await waitForProcessReady(
                 defenderProcess,
-                ['running', '8081'],
+                ['running', '28173'],
                 'MCP Defender started successfully',
                 'Timeout waiting for MCP Defender to start',
                 9000,
@@ -262,7 +262,7 @@ describe('MCP Defender Integration Tests', () => {
             // Wait for defender
             const defenderReady = await waitForProcessReady(
                 defenderProcess,
-                ['running', '8081'],
+                ['running', '28173'],
                 'MCP Defender started successfully',
                 'Timeout waiting for MCP Defender to start'
             );
@@ -274,7 +274,7 @@ describe('MCP Defender Integration Tests', () => {
             // Connect client
             client = await createSSEClient({
                 serverName: 'everything',
-                port: 8081,
+                port: 28173,
                 defaultTimeout: 10000
             });
         });

--- a/tests/unit/configurations/config-test.ts
+++ b/tests/unit/configurations/config-test.ts
@@ -144,7 +144,7 @@ describe('Standard MCP Configuration', () => {
 
         // Check for SSE proxy configuration
         const sseServer = processedConfig.mcpServers['test-sse'];
-        assert.ok(sseServer.url.includes('localhost:8081'), 'URL should be proxied to defender port');
+        assert.ok(sseServer.url.includes('localhost:28173'), 'URL should be proxied to defender port');
         assert.ok(sseServer.url.includes('/test-sse/sse'), 'URL should include server name');
         assert.strictEqual(sseServer.env.__MCP_PROXY_ORIGINAL_URL, 'http://localhost:3000/sse', 'Original URL should be stored');
     });
@@ -231,7 +231,7 @@ describe('VSCode MCP Configuration', () => {
 
         // Check for SSE proxy configuration
         const sseServer = processedConfig['mcp.servers']['test-sse'];
-        assert.ok(sseServer.url.includes('localhost:8081'), 'URL should be proxied to defender port');
+        assert.ok(sseServer.url.includes('localhost:28173'), 'URL should be proxied to defender port');
     });
 
     it('should restore the unprotected VSCode configuration', async () => {


### PR DESCRIPTION
Changes:
- Use Port: `28173`
- Enhance loading screen to show app icon
- Add build step to skip notarization for development purposes
- Fix icons not appearing in packaged apps
- Add PR template

<img width="912" alt="image" src="https://github.com/user-attachments/assets/8645ed72-d77c-4670-a9d1-ee4d6a15435b" />
