### PR TITLE
Disable sse proxying behind a settings flag

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+@MCP-Defender/mcp-defender-team 

--- a/src/components/settings/SettingsView.tsx
+++ b/src/components/settings/SettingsView.tsx
@@ -724,6 +724,38 @@ export default function SettingsView({ standalone = false }: SettingsViewProps) 
                                 </div>
                             )}
                         </div>
+
+                        {/* Transport Settings Section - commenting this out for now*/}
+                        {/* <div className="border-t pt-4 space-y-4">
+                            <div>
+                                <Label className="text-base">Transport Settings</Label>
+                                <p className="text-sm text-muted-foreground">
+                                    Configure how MCP communications are handled
+                                </p>
+                            </div>
+                            <div className="flex items-center justify-between space-x-2">
+                                <div>
+                                    <Label htmlFor="enable-sse-proxying" className="text-sm">Enable SSE Proxying</Label>
+                                    <p className="text-xs text-muted-foreground">
+                                        Proxy Server-Sent Events (SSE) transport through MCP Defender.
+                                        Disable if experiencing connection issues with SSE-based MCP servers.
+                                    </p>
+                                </div>
+                                <Switch
+                                    id="enable-sse-proxying"
+                                    checked={settings.enableSSEProxying}
+                                    onCheckedChange={(checked) => {
+                                        updateSettings({ enableSSEProxying: checked });
+                                    }}
+                                />
+                            </div>
+                            {!settings.enableSSEProxying && (
+                                <div className="mt-2 p-3 bg-blue-50 text-blue-800 rounded-md text-sm">
+                                    <strong>Note:</strong> SSE servers will not be protected when SSE proxying is disabled.
+                                    Only STDIO-based MCP servers will be monitored for security threats.
+                                </div>
+                            )}
+                        </div> */}
                     </div>
                 </CardContent>
             </Card>

--- a/src/services/settings/service.ts
+++ b/src/services/settings/service.ts
@@ -279,7 +279,8 @@ export class SettingsService extends BaseService {
             notificationSettings: NotificationSettings.CONFIG_UPDATES, // Enable config update notifications by default
             onboardingCompleted: false,
             disabledSignatures: new Set<string>(),
-            startOnLogin: true // Enable start on login by default for security app
+            startOnLogin: true, // Enable start on login by default for security app
+            enableSSEProxying: false // SSE transport is unstable, disabled by default
         };
     }
 

--- a/src/services/settings/types.ts
+++ b/src/services/settings/types.ts
@@ -55,4 +55,5 @@ export interface Settings {
     onboardingCompleted: boolean;
     disabledSignatures: Set<string> | string[]; // Set in memory, string[] for serialization
     startOnLogin: boolean; // Whether to start the app when user logs into their computer
+    enableSSEProxying: boolean; // Whether to proxy SSE (Server-Sent Events) transport through our server
 }


### PR DESCRIPTION
## Problem

Due to app compatibility issues, SSE protection should be done mcp-remote for remote sse servers as suggested by server authors.

## Changes

## Did you write or update any docs for this change?

- [ ] I've added or updated the docs
- [ ] I've reached out for help from the docs team
- [X ] No docs needed for this change

## How did you test this code?

Verification of app