### PR TITLE
Enhance before-quit handler to handle update flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mcp-defender",
   "productName": "MCP Defender",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "MCP Defender",
   "main": ".vite/build/main.js",
   "scripts": {


### PR DESCRIPTION
## Problem

When user tries to update the app, the app doesn't fully quit. This is because on quit we do some processing.

## Changes

There is no reliable way to detect an update has triggered the quit as per the official APIs alternatively a workaround is to set a timer, if the timer completes we can assume this quit was triggered by the updater, and force app quit to allow updater to run.

## Did you write or update any docs for this change?

- [ ] I've added or updated the docs
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

Requires testing upon next update.