### PR TITLE
Try renaming the output file to 'MCP Defender.zip'

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -82,6 +82,8 @@ const config: ForgeConfig = {
     icon: 'src/assets/1024x1024_logo', // The actual file must have .icns extension, but the .icns is omitted here.
     appBundleId: 'com.mcpdefender.app',
     appCategoryType: 'public.app-category.developer-tools',
+    // Override the name to remove version from filename
+    name: 'MCP Defender',
     protocols: [
       {
         name: 'MCP Defender',


### PR DESCRIPTION
## Problem

I’m working on getting the download link to directly download the latest zip

## Changes

Make electron publish a zip file without the version number so the link doesn’t change between versions

## Did you write or update any docs for this change?

- [ ] I've added or updated the docs
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Describe the steps you took -->