### PR TITLE
Change title status label to either "Enabled" or "Disabled"

### DIFF
--- a/src/components/TitleBar.tsx
+++ b/src/components/TitleBar.tsx
@@ -48,13 +48,13 @@ const TitleBar: React.FC<TitleBarProps> = ({
   const getDefenderStatusText = () => {
     switch (defenderState.status) {
       case DefenderStatus.running:
-        return "Protection Enabled";
+        return "Enabled";
       case DefenderStatus.starting:
         return "Starting...";
       case DefenderStatus.error:
         return "Error";
       case DefenderStatus.stopped:
-        return "Protection Disabled";
+        return "Disabled";
       default:
         return "Unknown";
     }

--- a/src/ipc-handlers/ui-manager.ts
+++ b/src/ipc-handlers/ui-manager.ts
@@ -362,7 +362,7 @@ export async function updateTrayContextMenu(state: DefenderState) {
         // Determine status text and icon
         let statusLabel = '';
         if (state.status === DefenderStatus.running) {
-            statusLabel = '🟢 Protection Enabled';
+            statusLabel = '🟢 Enabled';
         } else if (state.status === DefenderStatus.starting) {
             statusLabel = '🟡 Starting...';
         } else if (state.status === DefenderStatus.error) {


### PR DESCRIPTION


## Problem

The word 'Protection' is unnecessary in the title bar

## Changes

This changes "Protection Enabled" to just "Enabled" and same for "Disabled".

## Did you write or update any docs for this change?

- [ ] I've added or updated the docs
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Describe the steps you took -->