### PR TITLE
Return empty reason if request is allowed

### DIFF
--- a/src/defender/verification-utils.ts
+++ b/src/defender/verification-utils.ts
@@ -357,7 +357,7 @@ You are a security validator called MCP Defender that analyzes whether a MCP too
 
 SIGNATURE ID: [id]
 ALLOWED: [true/false]
-REASON: [short explanation of why the call is allowed or blocked]
+REASON: [short explanation of why the call is blocked - leave blank if allowed]
 
 6. Make your judgments strictly based on security concerns, not general helpfulness.
 7. Be specific about which aspects of the tool call triggered your decision.


### PR DESCRIPTION
## Problem

Right now a reason with an explanation is returned regardless of if it's allowed or blocked. Let's only return the reason when blocked to speed up responses

## Changes

Returns an empty reason if request is allowed