### PR TITLE
Remove shell metacharacters from command injection signatures

### DIFF
--- a/signatures/deterministic/command-injection.js
+++ b/signatures/deterministic/command-injection.js
@@ -15,7 +15,6 @@ function detectCommandInjection(toolInput, context) {
 
         // Command injection character patterns
         const injectionChars = [
-            /[;&|`$(){}\\[\]<>]/,  // Shell metacharacters
             /\|\s*\w+/,            // Pipes followed by commands
             /&&\s*\w+/,            // Command chaining with &&
             /;\s*\w+/              // Command separation with ;


### PR DESCRIPTION
Remove this regex as it matches common brackets in JSON