### PR TITLE
Prevent overcrowding of navbar

### DIFF
--- a/src/components/TitleBar.tsx
+++ b/src/components/TitleBar.tsx
@@ -149,7 +149,7 @@ const TitleBar: React.FC<TitleBarProps> = ({
       </div>
 
       {titleBarStyle == TitleBarStyle.Main && (
-        <div className="absolute top-0 right-4 h-[52px] webkit-app-region-no-drag flex items-center">
+        <div className="absolute top-0 right-0 h-[52px] webkit-app-region-no-drag flex items-center">
           <Button
             variant={"ghost"}
             size="icon"

--- a/src/ipc-handlers/ui-manager.ts
+++ b/src/ipc-handlers/ui-manager.ts
@@ -6,7 +6,7 @@ import { ServiceManager } from '../services/service-manager';
 import { createLogger } from '../utils/logger';
 import { notification } from '../utils/notification';
 
-const MIN_WINDOW_WIDTH = 650;
+const MIN_WINDOW_WIDTH = 800;
 const MIN_WINDOW_HEIGHT = 500;
 
 // Create a logger for the UI manager


### PR DESCRIPTION
Increased the minimum width of the app window and moved the settings button further right.

Before:
<img width="762" alt="Screenshot 2025-06-29 at 1 21 21 AM" src="https://github.com/user-attachments/assets/6493dabe-3bdd-44b8-96ea-f29aafd858b5" />

After:
<img width="912" alt="Screenshot 2025-06-29 at 1 21 46 AM" src="https://github.com/user-attachments/assets/32cfaee8-6e4f-44a4-9aad-819d0b402db3" />
